### PR TITLE
Use a case-sensitive module path for dRowAudio

### DIFF
--- a/plugin/Builds/LinuxMakefile/Makefile
+++ b/plugin/Builds/LinuxMakefile/Makefile
@@ -35,7 +35,7 @@ ifeq ($(CONFIG),Debug)
     TARGET_ARCH := -march=native
   endif
 
-  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DDEBUG=1 -D_DEBUG=1 -DJUCER_LINUX_MAKE_6D53C8B4=1 -DJUCE_APP_VERSION=1.0.5 -DJUCE_APP_VERSION_HEX=0x10005 $(shell pkg-config --cflags alsa freetype2 x11 xext xinerama libcurl) -pthread -I../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK -I../../JuceLibraryCode -I../../../modules/drowaudio/module -I../../../modules/gin/modules -I../../../modules/juce/modules -I../../../3rdparty/resid-0.16 -I../../../modules/slCommon $(CPPFLAGS)
+  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DDEBUG=1 -D_DEBUG=1 -DJUCER_LINUX_MAKE_6D53C8B4=1 -DJUCE_APP_VERSION=1.0.5 -DJUCE_APP_VERSION_HEX=0x10005 $(shell pkg-config --cflags alsa freetype2 x11 xext xinerama libcurl) -pthread -I../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK -I../../JuceLibraryCode -I../../../modules/dRowAudio/module -I../../../modules/gin/modules -I../../../modules/juce/modules -I../../../3rdparty/resid-0.16 -I../../../modules/slCommon $(CPPFLAGS)
 
   JUCE_CPPFLAGS_VST := -DJucePlugin_Build_VST=1 -DJucePlugin_Build_VST3=0 -DJucePlugin_Build_AU=0 -DJucePlugin_Build_AUv3=0 -DJucePlugin_Build_RTAS=0 -DJucePlugin_Build_AAX=0 -DJucePlugin_Build_Standalone=0 -DJucePlugin_Build_Unity=0
   JUCE_CFLAGS_VST := -fPIC -fvisibility=hidden
@@ -65,7 +65,7 @@ ifeq ($(CONFIG),Release)
     TARGET_ARCH := -march=native
   endif
 
-  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DNDEBUG=1 -DJUCER_LINUX_MAKE_6D53C8B4=1 -DJUCE_APP_VERSION=1.0.5 -DJUCE_APP_VERSION_HEX=0x10005 $(shell pkg-config --cflags alsa freetype2 x11 xext xinerama libcurl) -pthread -I../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK -I../../JuceLibraryCode -I../../../modules/drowaudio/module -I../../../modules/gin/modules -I../../../modules/juce/modules -I../../../3rdparty/resid-0.16 -I../../../modules/slCommon $(CPPFLAGS)
+  JUCE_CPPFLAGS := $(DEPFLAGS) -DLINUX=1 -DNDEBUG=1 -DJUCER_LINUX_MAKE_6D53C8B4=1 -DJUCE_APP_VERSION=1.0.5 -DJUCE_APP_VERSION_HEX=0x10005 $(shell pkg-config --cflags alsa freetype2 x11 xext xinerama libcurl) -pthread -I../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK -I../../JuceLibraryCode -I../../../modules/dRowAudio/module -I../../../modules/gin/modules -I../../../modules/juce/modules -I../../../3rdparty/resid-0.16 -I../../../modules/slCommon $(CPPFLAGS)
 
   JUCE_CPPFLAGS_VST := -DJucePlugin_Build_VST=1 -DJucePlugin_Build_VST3=0 -DJucePlugin_Build_AU=0 -DJucePlugin_Build_AUv3=0 -DJucePlugin_Build_RTAS=0 -DJucePlugin_Build_AAX=0 -DJucePlugin_Build_Standalone=0 -DJucePlugin_Build_Unity=0
   JUCE_CFLAGS_VST := -fPIC -fvisibility=hidden

--- a/plugin/Builds/MacOSX/SID.xcodeproj/project.pbxproj
+++ b/plugin/Builds/MacOSX/SID.xcodeproj/project.pbxproj
@@ -602,7 +602,7 @@
 			isa = PBXFileReference;
 			lastKnownFileType = file;
 			name = dRowAudio;
-			path = ../../../modules/drowaudio/module/dRowAudio;
+			path = ../../../modules/dRowAudio/module/dRowAudio;
 			sourceTree = "SOURCE_ROOT";
 		};
 		74E7E764B3E3E82B66E023F8 = {
@@ -1229,7 +1229,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1287,7 +1287,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1344,7 +1344,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1403,7 +1403,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1458,7 +1458,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1510,7 +1510,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1562,7 +1562,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",
@@ -1614,7 +1614,7 @@
 					"../../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK",
 					"/Users/rrabien/SDKs/vstsdk2.4",
 					"../../JuceLibraryCode",
-					"../../../modules/drowaudio/module",
+					"../../../modules/dRowAudio/module",
 					"../../../modules/gin/modules",
 					"../../../modules/juce/modules",
 					"../../../3rdparty/resid-0.16",

--- a/plugin/Builds/VisualStudio2017/SID_SharedCode.vcxproj
+++ b/plugin/Builds/VisualStudio2017/SID_SharedCode.vcxproj
@@ -95,7 +95,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -142,7 +142,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -192,7 +192,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -235,7 +235,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -289,196 +289,196 @@
     <ClCompile Include="..\..\..\3rdparty\resid-0.16\wave8580_PST.cc"/>
     <ClCompile Include="..\..\Source\PluginProcessor.cpp"/>
     <ClCompile Include="..\..\Source\PluginEditor.cpp"/>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_FFT.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_FFT.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_mac_FFTOperation.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_mac_FFTOperation.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_Window.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_Window.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\AAFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\AAFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\BPMDetect.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\BPMDetect.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_gcc.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_gcc.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_win.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_win.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_gcc.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_gcc.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_win.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_win.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIRFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIRFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\mmx_optimized.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\mmx_optimized.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\PeakFinder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\PeakFinder.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\RateTransposer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\RateTransposer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch_Source.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch_Source.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\sse_optimized.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\sse_optimized.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\TDStretch.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\TDStretch.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioUtilityUnitTests.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioUtilityUnitTests.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_PitchDetector.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_PitchDetector.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Clock.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Clock.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CpuMeter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CpuMeter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_DefaultColours.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_DefaultColours.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Sonogram.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Sonogram.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectrograph.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectrograph.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectroscope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectroscope.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_MathsUnitTests.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_MathsUnitTests.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLEasySession.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLEasySession.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLManager.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLManager.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_EncryptedString.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_EncryptedString.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\dRowAudio.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\dRowAudio.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\modules\gin\modules\gin\3rdparty\muParser\muParser.cpp">
@@ -2473,115 +2473,115 @@
     <ClInclude Include="..\..\..\3rdparty\resid-0.16\wave.h"/>
     <ClInclude Include="..\..\Source\PluginProcessor.h"/>
     <ClInclude Include="..\..\Source\PluginEditor.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\Array.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\Array.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\def.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\DynArray.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\DynArray.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTReal.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTReal.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLenParam.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.hpp"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_FFT.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_Window.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\AAFilter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\BPMDetect.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSamplePipe.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIRFilter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\PeakFinder.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\RateTransposer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\soundtouch_config.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch_Includes.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\STTypes.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\TDStretch.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioUtility.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_Buffer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FifoBuffer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_Pitch.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_PitchDetector.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowserLookAndFeel.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Clock.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CpuMeter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_DefaultColours.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GuiHelpers.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Sonogram.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectrograph.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectroscope.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_BezierCurve.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_CumulativeMovingAverage.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_MathsUtilities.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AudioPicker.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curl.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlbuild.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlrules.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlver.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\easy.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\mprintf.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\multi.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\stdcheaders.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\typecheck-gcc.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLEasySession.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLManager.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_StreamAndFileHandler.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Comparators.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Constants.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_DebugObject.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_EncryptedString.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_LockedPointer.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_MusicLibraryHelpers.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_StateVariable.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Utility.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_XmlHelpers.h"/>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\dRowAudio.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\Array.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\Array.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\def.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\DynArray.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\DynArray.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTReal.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTReal.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLenParam.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.hpp"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_FFT.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_Window.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\AAFilter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\BPMDetect.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSamplePipe.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIRFilter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\PeakFinder.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\RateTransposer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\soundtouch_config.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch_Includes.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\STTypes.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\TDStretch.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioUtility.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_Buffer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FifoBuffer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_Pitch.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_PitchDetector.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowserLookAndFeel.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Clock.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CpuMeter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_DefaultColours.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GuiHelpers.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Sonogram.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectrograph.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectroscope.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_BezierCurve.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_CumulativeMovingAverage.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_MathsUtilities.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AudioPicker.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curl.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlbuild.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlrules.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlver.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\easy.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\mprintf.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\multi.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\stdcheaders.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\typecheck-gcc.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLEasySession.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLManager.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_StreamAndFileHandler.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Comparators.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Constants.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_DebugObject.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_EncryptedString.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_LockedPointer.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_MusicLibraryHelpers.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_StateVariable.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Utility.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_XmlHelpers.h"/>
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\dRowAudio.h"/>
     <ClInclude Include="..\..\..\modules\gin\modules\gin\3rdparty\avir\avir.h"/>
     <ClInclude Include="..\..\..\modules\gin\modules\gin\3rdparty\avir\avir_dil.h"/>
     <ClInclude Include="..\..\..\modules\gin\modules\gin\3rdparty\avir\avir_float4_sse.h"/>

--- a/plugin/Builds/VisualStudio2017/SID_SharedCode.vcxproj.filters
+++ b/plugin/Builds/VisualStudio2017/SID_SharedCode.vcxproj.filters
@@ -601,208 +601,208 @@
     <ClCompile Include="..\..\Source\PluginEditor.cpp">
       <Filter>SID\Source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_FFT.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_FFT.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_mac_FFTOperation.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_mac_FFTOperation.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_Window.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_Window.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\filters</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\filters</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\AAFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\AAFilter.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\BPMDetect.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\BPMDetect.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_gcc.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_gcc.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_win.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x64_win.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_gcc.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_gcc.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_win.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect_x86_win.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIRFilter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIRFilter.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\mmx_optimized.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\mmx_optimized.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\PeakFinder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\PeakFinder.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\RateTransposer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\RateTransposer.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch_Source.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch_Source.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\sse_optimized.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\sse_optimized.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\TDStretch.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\TDStretch.cpp">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioUtilityUnitTests.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioUtilityUnitTests.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_PitchDetector.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_PitchDetector.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.cpp">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\filebrowser</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.cpp">
       <Filter>JUCE Modules\dRowAudio\gui\filebrowser</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Clock.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Clock.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CpuMeter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CpuMeter.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_DefaultColours.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_DefaultColours.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Sonogram.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Sonogram.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectrograph.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectrograph.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectroscope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectroscope.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.cpp">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_MathsUnitTests.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_MathsUnitTests.cpp">
       <Filter>JUCE Modules\dRowAudio\maths</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AudioPicker.mm">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AudioPicker.mm">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.mm">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.mm">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.mm">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.mm">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLEasySession.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLEasySession.cpp">
       <Filter>JUCE Modules\dRowAudio\network</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLManager.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLManager.cpp">
       <Filter>JUCE Modules\dRowAudio\network</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.cpp">
       <Filter>JUCE Modules\dRowAudio\parameters</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.cpp">
       <Filter>JUCE Modules\dRowAudio\streams</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_EncryptedString.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_EncryptedString.cpp">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.cpp">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.cpp">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.cpp">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.cpp">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\dRowAudio.cpp">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\dRowAudio.cpp">
       <Filter>JUCE Modules\dRowAudio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\modules\drowaudio\module\dRowAudio\dRowAudio.mm">
+    <ClCompile Include="..\..\..\modules\dRowAudio\module\dRowAudio\dRowAudio.mm">
       <Filter>JUCE Modules\dRowAudio</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\modules\gin\modules\gin\3rdparty\muParser\muParser.cpp">
@@ -2994,331 +2994,331 @@
     <ClInclude Include="..\..\Source\PluginEditor.h">
       <Filter>SID\Source</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\Array.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\Array.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\Array.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\Array.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\def.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\def.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\DynArray.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\DynArray.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\DynArray.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\DynArray.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTReal.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTReal.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTReal.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTReal.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLen.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLenParam.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealFixLenParam.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassDirect.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealPassInverse.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealSelect.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\FFTRealUseTrigo.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.hpp">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\fftreal\OscSinCos.hpp">
       <Filter>JUCE Modules\dRowAudio\audio\fft\fftreal</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_FFT.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_FFT.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_LTAS.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\fft\dRowAudio_Window.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\fft\dRowAudio_Window.h">
       <Filter>JUCE Modules\dRowAudio\audio\fft</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_BiquadFilter.h">
       <Filter>JUCE Modules\dRowAudio\audio\filters</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\filters\dRowAudio_OnePoleFilter.h">
       <Filter>JUCE Modules\dRowAudio\audio\filters</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\AAFilter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\AAFilter.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\BPMDetect.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\BPMDetect.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\cpu_detect.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\cpu_detect.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSampleBuffer.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIFOSamplePipe.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIFOSamplePipe.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\FIRFilter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\FIRFilter.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\PeakFinder.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\PeakFinder.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\RateTransposer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\RateTransposer.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\soundtouch_config.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\soundtouch_config.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\SoundTouch_Includes.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\SoundTouch_Includes.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\STTypes.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\STTypes.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\soundtouch\TDStretch.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\soundtouch\TDStretch.h">
       <Filter>JUCE Modules\dRowAudio\audio\soundtouch</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayer.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioFilePlayerExt.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioSampleBufferAudioFormat.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_AudioUtility.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_AudioUtility.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_Buffer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_Buffer.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_EnvelopeFollower.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FifoBuffer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FifoBuffer.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_FilteringAudioSource.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_LoopingAudioSource.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_Pitch.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_Pitch.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_PitchDetector.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_PitchDetector.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_ReversibleAudioSource.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SampleRateConverter.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchAudioSource.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\audio\dRowAudio_SoundTouchProcessor.h">
       <Filter>JUCE Modules\dRowAudio\audio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_AudioThumbnailImage.h">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_ColouredAudioThumbnail.h">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_DraggableWaveDisplay.h">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\audiothumbnail\dRowAudio_PositionableWaveDisplay.h">
       <Filter>JUCE Modules\dRowAudio\gui\audiothumbnail</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_BasicFileBrowser.h">
       <Filter>JUCE Modules\dRowAudio\gui\filebrowser</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowser.h">
       <Filter>JUCE Modules\dRowAudio\gui\filebrowser</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowserLookAndFeel.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\filebrowser\dRowAudio_ColumnFileBrowserLookAndFeel.h">
       <Filter>JUCE Modules\dRowAudio\gui\filebrowser</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioFileDropTarget.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioOscilloscope.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_AudioTransportCursor.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CentreAlignViewport.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Clock.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Clock.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_CpuMeter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_CpuMeter.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_DefaultColours.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_DefaultColours.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GraphicalComponent.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_GuiHelpers.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_GuiHelpers.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_MusicLibraryTable.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_SegmentedMeter.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Sonogram.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Sonogram.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectrograph.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectrograph.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_Spectroscope.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_Spectroscope.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\gui\dRowAudio_TriggeredScope.h">
       <Filter>JUCE Modules\dRowAudio\gui</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_BezierCurve.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_BezierCurve.h">
       <Filter>JUCE Modules\dRowAudio\maths</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_CumulativeMovingAverage.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_CumulativeMovingAverage.h">
       <Filter>JUCE Modules\dRowAudio\maths</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\maths\dRowAudio_MathsUtilities.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\maths\dRowAudio_MathsUtilities.h">
       <Filter>JUCE Modules\dRowAudio\maths</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AudioPicker.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AudioPicker.h">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_AVAssetAudioFormat.h">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\native\dRowAudio_IOSAudioConverter.h">
       <Filter>JUCE Modules\dRowAudio\native</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curl.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curl.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlbuild.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlbuild.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlrules.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlrules.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\curlver.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\curlver.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\easy.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\easy.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\mprintf.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\mprintf.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\multi.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\multi.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\stdcheaders.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\stdcheaders.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\curl\include\curl\typecheck-gcc.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\curl\include\curl\typecheck-gcc.h">
       <Filter>JUCE Modules\dRowAudio\network\curl\include\curl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLEasySession.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLEasySession.h">
       <Filter>JUCE Modules\dRowAudio\network</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\network\dRowAudio_CURLManager.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\network\dRowAudio_CURLManager.h">
       <Filter>JUCE Modules\dRowAudio\network</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\parameters\dRowAudio_PluginParameter.h">
       <Filter>JUCE Modules\dRowAudio\parameters</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_MemoryInputSource.h">
       <Filter>JUCE Modules\dRowAudio\streams</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\streams\dRowAudio_StreamAndFileHandler.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\streams\dRowAudio_StreamAndFileHandler.h">
       <Filter>JUCE Modules\dRowAudio\streams</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Comparators.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Comparators.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Constants.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Constants.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_DebugObject.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_DebugObject.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_EncryptedString.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_EncryptedString.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibrary.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_ITunesLibraryParser.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_LockedPointer.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_LockedPointer.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_MusicLibraryHelpers.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_MusicLibraryHelpers.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_StateVariable.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_StateVariable.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityBuilder.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_UnityProjectBuilder.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_Utility.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_Utility.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\utility\dRowAudio_XmlHelpers.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\utility\dRowAudio_XmlHelpers.h">
       <Filter>JUCE Modules\dRowAudio\utility</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\modules\drowaudio\module\dRowAudio\dRowAudio.h">
+    <ClInclude Include="..\..\..\modules\dRowAudio\module\dRowAudio\dRowAudio.h">
       <Filter>JUCE Modules\dRowAudio</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\modules\gin\modules\gin\3rdparty\avir\avir.h">

--- a/plugin/Builds/VisualStudio2017/SID_StandalonePlugin.vcxproj
+++ b/plugin/Builds/VisualStudio2017/SID_StandalonePlugin.vcxproj
@@ -99,7 +99,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -147,7 +147,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -198,7 +198,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -245,7 +245,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>

--- a/plugin/Builds/VisualStudio2017/SID_VST.vcxproj
+++ b/plugin/Builds/VisualStudio2017/SID_VST.vcxproj
@@ -99,7 +99,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -147,7 +147,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -198,7 +198,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -245,7 +245,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Full</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\drowaudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\modules\juce\modules\juce_audio_processors\format_types\VST3_SDK;C:\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\..\modules\dRowAudio\module;..\..\..\modules\gin\modules;..\..\..\modules\juce\modules;../../../3rdparty/resid-0.16;../../../modules/slCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;VERSION=&quot;0.16&quot;;JUCER_VS2017_78A5024=1;JUCE_APP_VERSION=1.0.5;JUCE_APP_VERSION_HEX=0x10005;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_RTAS=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>

--- a/plugin/SID.jucer
+++ b/plugin/SID.jucer
@@ -79,7 +79,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_plugin_client" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="juce_audio_utils" path="../modules/juce/modules"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
@@ -123,7 +123,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_plugin_client" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="juce_audio_utils" path="../modules/juce/modules"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
@@ -155,7 +155,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_devices" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_basics" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_dsp" path="../modules/gin/modules"/>


### PR DESCRIPTION
The module is not found on a case-sensitive filesystem; I have updated the paths so it will work.

It's a step in fixing the current Linux build (it has some other problems left).